### PR TITLE
【修正】選択肢のキーがキャメルケースでレスポンスするよう修正

### DIFF
--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::CoursesController < ApplicationController
     all_words = @course.words.to_a
     @words = all_words.map do |word|
       dummy_words = all_words.reject { |w| w.id == word.id }.shuffle.take(3)
-      word.attributes.symbolize_keys.merge(choices: generate_choices([word, *dummy_words]))
+      word.attributes.transform_keys { |key| key.to_s.camelize(:lower) }.merge(choices: generate_choices([word, *dummy_words]))
     end
   end
 
@@ -16,7 +16,7 @@ class Api::V1::CoursesController < ApplicationController
 
     def generate_choices(words)
       words.map do |word|
-        word.attributes.symbolize_keys.merge(is_correct: word.id == words.first.id)
+        word.attributes.transform_keys { |key| key.to_s.camelize(:lower) }.merge(isCorrect: word.id == words.first.id)
       end
     end
 end

--- a/spec/requests/api/v1/courses_spec.rb
+++ b/spec/requests/api/v1/courses_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe 'Api::V1::Courses', type: :request do
     it 'return choices with is_correct attribute' do
       get api_v1_course_path(course)
       json = JSON.parse(response.body)
-      expect(json['words'][0]['choices'].first['is_correct']).to eq(true)
-      expect(json['words'][0]['choices'].last['is_correct']).to eq(false)
+      expect(json['words'][0]['choices'].first['isCorrect']).to eq(true)
+      expect(json['words'][0]['choices'].last['isCorrect']).to eq(false)
     end
   end
 end


### PR DESCRIPTION
これの原因は、active recordを一旦ハッシュ形式にしているため。
（ハッシュ形式にしたのは、SQLの発行数を極力抑えるため）