### PR TITLE
【バグ】他人が学習した単語が、出題の対象から外れる

### DIFF
--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -47,7 +47,9 @@ class Word < ApplicationRecord
   scope :selected_by_next_schedule, lambda { |user_id:|
     left_joins(:records)
       .where(records: { user_id:, next_scheduled_question_at: ..Time.current })
-      .or(where.missing(:records))
+      .or(where.not(
+            id: WordRecord.where(user_id:).select(:word_id)
+          ))
       # === Order by the above priority. ===
       # 1. "status": "correct(2)" → "incorrect(1)" → nil(0)
       # 2. "step": large → small


### PR DESCRIPTION
closes #47 

This commit optimizes the `selected_by_next_schedule` query in the `Word` model. It replaces the `where.missing(:records)` condition with a more efficient `where.not` condition using a subquery. The new condition excludes words that have associated `WordRecord` records for the given `user_id`. The query is also updated to order the results based on the priority of status, step, and next_scheduled_question_at.